### PR TITLE
実装追加内容をmasterへマージ。

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,6 @@ http://18.179.164.30/
  - フォロー機能の改善（機能を実装しただけで使い勝手が悪い状態）
  - 手が回っていない細かいviewの修正
 
+## SNS
+ - Twitter: https://twitter.com/DTensyo
+ - Qiita: https://qiita.com/dr_tensyo

--- a/app/assets/javascripts/add-equip-form.js
+++ b/app/assets/javascripts/add-equip-form.js
@@ -1,0 +1,49 @@
+$(function(){
+  $(document).ready(function() {
+    const addEquipmentForm = (index)=> {
+      var html = `
+          <div class= "equipForm" data-equipment="${index}">
+            <div class="post_create_content__form">
+              <div class="post_create_content__form__upper">
+                <label class="post_create_content__form__upper__name" for="post_gears_attributes_${index}_機材名">機材名(No.${index + 1})</label>
+                <div class="post_create_content__form__upper--icon">
+                  <div id="optional">任意</div>
+                </div>
+              </div>
+              <input placeholder="品番、メーカーなど" class="post_create_content__form__under" type="text" name="post[gears_attributes][${index}][equipment]" id="post_gears_attributes_${index}_equipment">
+            </div>
+            <div class="post_create_content__form">
+              <div class="post_create_content__form__upper" data-equ-comment="${index}">
+                <label class="post_create_content__form__upper__name--sub" for="post_gears_attributes_${index}_機材詳細">機材詳細</label>
+                <div class="post_create_content__form__upper--icon">
+                  <div id="optional">任意</div>
+                </div>
+              </div>
+              <input placeholder="機材についての詳細" class="post_create_content__form__under" type="text" name="post[gears_attributes][${index}][equ_comment]" id="post_gears_attributes_${index}_equ_comment">
+            </div>
+          </div>`
+      return html;
+    }
+
+    let equIndex = [1,2,3,4,5,6,7,8,9,10];
+
+    lastIndex = $('.equipForm').data('index');
+    equIndex.splice(0, lastIndex);
+    $('.hidden-destroy').hide();
+
+    // 追加するボタンをクリックした時の処理
+    $(document).on('click','#addEquipDetail',function(){
+      $('#equipDetailListArea').append(addEquipmentForm(equIndex[0]));
+      equIndex.shift();
+      equIndex.push(equIndex[equIndex.length - 1] + 1)
+    });
+
+    $(document).on('click','#removeEquipDetail',function(){
+      if($('.equipForm:last').data('equipment') == 0){
+      }else{
+        $('.equipForm:last').remove();
+        equIndex.unshift(equIndex[0] - 1);
+      }
+    });
+  });
+});

--- a/app/assets/stylesheets/_post_create.scss
+++ b/app/assets/stylesheets/_post_create.scss
@@ -17,6 +17,11 @@
       &__name{
         font-size: 18px;
         font-weight: bold;
+        &--sub{
+          font-size: 14px;
+          font-weight: bold;
+          color: $theme-font-sub-color;
+        }
       }
     }
     &__under{
@@ -55,9 +60,43 @@
     margin-top:32px;
     margin-bottom: 32px;
   }
+  &__optionForm{
+    margin-bottom: 24px;
+    display: flex;
+    justify-content: flex-end;
+    &__info{
+      line-height: 34px;
+      font-weight: bold;
+      font-size: 12px;
+      margin-right: 8px;
+    }
+    &--add{
+      width: 45px;
+      background-color: $add-btn-color;
+      // border: 1px solid $add-btn-border-color;
+      border-radius: 4px;
+      color: #fff;
+      // color:$add-btn-font-color;
+      margin-right: 16px;
+    }
+    &--remove{
+      width: 45px;
+      background-color: $remove-btn-color;
+      // border: 1px solid $remove-btn-border-color;
+      border-radius: 4px;
+      color: $remove-btn-font-color;
+    }
+  }
 }
 
 .between-detail-margin{
   display: block;
   margin-top: 32px;
+}
+
+.optionIcon{
+  text-align: center;
+  padding: 5px 0;
+  font-size: 16px;
+  cursor : pointer;
 }

--- a/app/assets/stylesheets/_theme.scss
+++ b/app/assets/stylesheets/_theme.scss
@@ -5,6 +5,7 @@ $theme-accent-color:#f26900e4;
 $theme-accent-sub-color:#bb5201e0;
 
 $theme-font-color: #131d25;
+$theme-font-sub-color:#333c43;
 
 $post-detail-width: calc(100% - 30px);
 $post-detail-padding:20px 15px;
@@ -12,3 +13,15 @@ $post-detail-padding:20px 15px;
 $user-detail-width: calc(80% - 40px);
 $sign-detail-width: 50%;
 $edit-btn-color: #134db1f3;
+
+// ボタンの種類別共通カラー設定
+$positive-btn-color:rgb(232, 139, 0);
+$negative-btn-color:rgb(193, 198, 211);
+
+
+$add-btn-color:rgb(249, 174, 44);
+$add-btn-border-color:rgb(206, 156, 68);
+$add-btn-font-color:rgb(97, 83, 58);
+$remove-btn-color:rgb(255, 255, 255);
+$remove-btn-border-color: #8daac2;
+$remove-btn-font-color:rgb(61, 75, 84);

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -2,22 +2,22 @@ class PostsController < ApplicationController
 before_action :set_post, only: [:show]
 
 
-  class PostForm
-    include ActiveModel::Model #テーブルは持たないが、ApplicationRecordのsaveメソッドなどを提供
+  # class PostForm
+  #   include ActiveModel::Model #テーブルは持たないが、ApplicationRecordのsaveメソッドなどを提供
   
-    attr_accessor :comment, :image, :equipment, :equ_comment, :post_id, :user_id
+  #   attr_accessor :comment, :image, :equipment, :equ_comment, :post_id, :user_id
   
-    validates :image, presence: true
+  #   validates :image, presence: true
   
-    def save
-      return false if invalid? #バリデーションを追加する場合はここに追加
+  #   def save
+  #     return false if invalid? #バリデーションを追加する場合はここに追加
   
-      #postインスタンスを作成。Postsテーブルの各種カラムを引数で指定してあげる。この段階で各種パラメータはnilとなっていると思う
-      post = Post.new(comment: comment,image: image, user_id: user_id)
-      post.gears.new(equipment: equipment,equ_comment: equ_comment, post_id: post_id)
-      post.save
-    end
-  end
+  #     #postインスタンスを作成。Postsテーブルの各種カラムを引数で指定してあげる。この段階で各種パラメータはnilとなっていると思う
+  #     post = Post.new(comment: comment,image: image, user_id: user_id)
+  #     post.gears.new(equipment: equipment,equ_comment: equ_comment, post_id: post_id)
+  #     post.save
+  #   end
+  # end
 
   
   def index
@@ -30,12 +30,20 @@ before_action :set_post, only: [:show]
   end
 
   def new
-    @post_form = PostForm.new
+    # @post_form = PostForm.new
+    @post = Post.new
+    @post.gears.new
   end
 
   def create
-    @post_form = PostForm.new(post_params)
-    if @post_form.save
+    # @post_form = PostForm.new(post_params)
+    # if @post_form.save
+    #   redirect_to root_path, notice: '保存されました'
+    # else
+    #   redirect_to root_path
+    # end
+    @post = Post.new(post_params)
+    if @post.save
       redirect_to root_path, notice: '保存されました'
     else
       redirect_to root_path
@@ -65,12 +73,15 @@ before_action :set_post, only: [:show]
     @post = Post.find(params[:id])
   end
 
-
   def post_params
-    params.require(:posts_controller_post_form).permit(:comment, :image, :equipment, :equ_comment, :post_id).merge(user_id: current_user.id)
+    params.require(:post).permit(:comment,:image, :user_id, gears_attributes: [:equipment, :equ_comment, :_destroy, :id])
   end
 
+  # def post_params
+  #   params.require(:posts_controller_post_form).permit(:comment, :image, :equipment, :equ_comment, :post_id).merge(user_id: current_user.id)
+  # end
+
   def post_update_params
-    params.require(:post).permit(:comment, :image,gears_attributes: [:equipment,:equ_comment,:_destroy,:id])
+    params.require(:post).permit(:comment, :image, gears_attributes: [:equipment,:equ_comment,:_destroy,:id])
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,13 +1,12 @@
 class Post < ApplicationRecord
 
   belongs_to :user
+  has_many :comments
   has_many :gears, dependent: :destroy
   accepts_nested_attributes_for :gears,allow_destroy: true
-  has_many :comments
 
-  # # postsテーブルにgearsテーブルをネストさせる処理
-  # accepts_nested_attributes_for :gears
-
+  validates :image, presence: true
+  
   #postsテーブルに対して、画像アップロードを可能にするためマウント
   mount_uploader :image, ImageUploader
 end

--- a/app/views/posts/edit.html.haml
+++ b/app/views/posts/edit.html.haml
@@ -25,22 +25,38 @@
       %hr
 
       = f.fields_for :gears do |i|
-        -@post.gears.each_with_index do |gear, index|
-          .post_create_content__form
-            .post_create_content__form__upper
-              = i.label "機材名",class: "post_create_content__form__upper__name"
-              .post_create_content__form__upper--icon
-                #optional 任意
-            = i.text_field :equipment,autocomplete: "equipment",placeholder: "品番、メーカーなど", class: "post_create_content__form__under"
+        #equipDetailListArea
+          .equipForm{data: {equipment: "#{i.index}"}}
+            .post_create_content__form{data: {equipment: "#{i.index}"}}
+              .post_create_content__form__upper
+                = i.label "機材名",class: "post_create_content__form__upper__name"
+                .post_create_content__form__upper--icon
+                  #optional 任意
+              = i.text_field :equipment,placeholder: "品番、メーカーなど", class: "post_create_content__form__under"
+              -if @post.persisted?
+                = i.check_box :_destroy,data:{ index: i.index }, class: 'hidden-destroy'
+            .post_create_content__form
+              .post_create_content__form__upper{data: {equ_comment: "#{i.index}"}}
+                = i.label "機材詳細",class: "post_create_content__form__upper__name"
+                .post_create_content__form__upper--icon
+                  #optional 任意
+              = i.text_field :equ_comment,placeholder: "機材についての詳細", class: "post_create_content__form__under"
+              -if @post.persisted?
+                = i.check_box :_destroy,data:{ index: i.index }, class: 'hidden-destroy'
 
-          .post_create_content__form
-            .post_create_content__form__upper
-              = i.label "機材詳細",class: "post_create_content__form__upper__name"
-              .post_create_content__form__upper--icon
-                #optional 任意
-            = i.text_field :equ_comment, autocomplete: "equ_comment",placeholder: "機材についての詳細", class: "post_create_content__form__under"
-      = f.hidden_field :user_id, value: @post.user_id
+      .post_create_content__optionForm
+        .post_create_content__optionForm__info
+          詳細項目の追加/削除
+        .post_create_content__optionForm--add
+          #addEquipDetail.optionIcon
+            =icon('far','plus-square')
+        .post_create_content__optionForm--remove
+          #removeEquipDetail.optionIcon
+            =icon('far','minus-square')
 
-    
+
+      = f.hidden_field :user_id, value: current_user.id
+      .post_create_content__optionForm
+
       .post_create_content__btnArea
         = f.submit "投稿を編集する", id: "activeBtn"

--- a/app/views/posts/new.html.haml
+++ b/app/views/posts/new.html.haml
@@ -3,7 +3,9 @@
     %h2 機材の投稿
     %hr
 
-    = form_for(@post_form, url: {controller: 'posts',action: 'create'}) do |f|
+    -# = form_for(@post_form, url: {controller: 'posts',action: 'create'}) do |f|
+    -# post_formを使わずに投稿できるようにリファクタ
+    = form_for(@post, url: {controller: 'posts',action: 'create'}) do |f|
       .post_create_content__form
         .post_create_content__form__upper
           = f.label "コメント・自慢ポイント",class: "post_create_content__form__upper__name"
@@ -15,7 +17,7 @@
         .post_create_content__form__upper
           = f.label "機材画像",class: "post_create_content__form__upper__name"
           .post_create_content__form__upper--icon
-            #optional 任意
+            #requier 必須
       .post_create_content__form__underImgForm--view
         = image_tag "", id: "uploadImg"
       .post_create_content__form__underImgForm
@@ -24,21 +26,34 @@
       %h2 機材詳細
       %hr
 
-      .post_create_content__form
-        .post_create_content__form__upper
-          = f.label "機材名",class: "post_create_content__form__upper__name"
-          .post_create_content__form__upper--icon
-            #optional 任意
-        = f.text_field :equipment,placeholder: "品番、メーカーなど", class: "post_create_content__form__under"
+      = f.fields_for :gears do |i|
+        #equipDetailListArea
+          .equipForm{data: {equipment: "#{i.index}"}}
+            .post_create_content__form
+              .post_create_content__form__upper
+                = i.label "機材名",class: "post_create_content__form__upper__name"
+                .post_create_content__form__upper--icon
+                  #optional 任意
+              = i.text_field :equipment,placeholder: "品番、メーカーなど", class: "post_create_content__form__under"
 
-      .post_create_content__form
-        .post_create_content__form__upper
-          = f.label "機材詳細",class: "post_create_content__form__upper__name"
-          .post_create_content__form__upper--icon
-            #optional 任意
-        = f.text_field :equ_comment,placeholder: "機材についての詳細", class: "post_create_content__form__under"
-        = f.hidden_field :cid, :value => ""
-        = f.hidden_field :userid, :value => ""
-    
+            .post_create_content__form
+              .post_create_content__form__upper{data: {equ_comment: "#{i.index}"}}
+                = i.label "機材詳細",class: "post_create_content__form__upper__name--sub"
+                .post_create_content__form__upper--icon
+                  #optional 任意
+              = i.text_field :equ_comment,placeholder: "機材についての詳細", class: "post_create_content__form__under"
+
+        .post_create_content__optionForm
+          .post_create_content__optionForm__info
+            詳細項目の追加/削除
+          .post_create_content__optionForm--add
+            #addEquipDetail.optionIcon
+              =icon('far','plus-square')
+          .post_create_content__optionForm--remove
+            #removeEquipDetail.optionIcon
+              =icon('far','minus-square')
+
+      = f.hidden_field :user_id, value: current_user.id
+
       .post_create_content__btnArea
         = f.submit "show off!", id: "activeBtn"

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -5,19 +5,21 @@
       .user_contents__upper-info__profile--name
         = "#{@user.name}　さん"
     .user_contents__upper-info__action
-      -if user_signed_in? && current_user.id == @user.id
-        = link_to destroy_user_session_path,class: "user_contents__upper-info__action--edit", method: :delete do
-          = icon('fas', 'sign-out-alt')
-          ログアウト
-          %br
-        = link_to edit_user_registration_path, class:"user_contents__upper-info__action--sign-out", method: :get do
-          = icon('fas', 'user-edit')
-          編集
-      - else
-        = link_to user_messages_path(@user.id), class: "user_contents__upper-info__action--edit" do
-          = icon('far', 'envelope')
-          メッセージを送る
-        = render partial: 'relationships/follow_button', user: @user
+      -if user_signed_in?
+        -if current_user.id == @user.id
+          = link_to destroy_user_session_path,class: "user_contents__upper-info__action--edit", method: :delete do
+            = icon('fas', 'sign-out-alt')
+            ログアウト
+            %br
+          = link_to edit_user_registration_path, class:"user_contents__upper-info__action--sign-out", method: :get do
+            = icon('fas', 'user-edit')
+            編集
+        - else
+          = link_to user_messages_path(@user.id), class: "user_contents__upper-info__action--edit" do
+            = icon('far', 'envelope')
+            メッセージを送る
+          = render partial: 'relationships/follow_button', user: @user
+      -else
   
 
   .user_contents__under-info


### PR DESCRIPTION
# What
・新規投稿画面の実装をリファクタリング
・postテーブルに紐づいた子テーブルgearsテーブルへ複数レコード追加可能に実装
・jQueryを利用して入力フォームの追加、削除を実装

# Why
既存の実装だと複数レコード追加が現実的ではなかったため、リファクタリング。
複数レコード追加させたい意図としては、一つの投稿で複数の機材を載せて自慢する事を可能とするため。